### PR TITLE
Add zopen_get_version for xxhash

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -45,3 +45,7 @@ zopen_check_results()
   return 3 # non-functional
 }
 
+zopen_get_version()
+{
+    ./xxh32sum -V 2>&1 | head -1 | awk '{print $2}'
+}


### PR DESCRIPTION
I can not get the version part from ./xxh32sum -V with grep/awk/cut/sed/... I am not 100% sure if redirects stderr to stdout is the right way to do it but it works.